### PR TITLE
Remove vello reexport

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,6 @@ use vello::kurbo::{Affine, BezPath, Point, Rect, Stroke};
 use vello::peniko::{BlendMode, Blob, Brush, Color, Fill, Image};
 use vello::Scene;
 
-/// Re-export vello.
-pub use vello;
-
 /// Re-export usvg.
 pub use usvg;
 


### PR DESCRIPTION
I removed the pub use vello; reexport from vello_svg as I found it disturbing when using it on a project that already used vello and ships vello_svg as an addition behind a feature flag, as well as velato, which also reexports vello currently.