### PR TITLE
fix: ViewBox transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+### changed
+
+- Updated usvg to 0.41
+
+### fixed
+
+- The image viewBox is now properly translated
+
 ## 0.1 (2024-03-11)
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ### changed
 
-- Updated usvg to 0.41
+- Updated `usvg` to 0.41
 
 ### fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,13 +74,7 @@ pub fn render_tree_with<F: FnMut(&mut Scene, &usvg::Node) -> Result<(), E>, E>(
     ts: &usvg::Transform,
     error_handler: &mut F,
 ) -> Result<(), E> {
-    render_tree_impl(
-        scene,
-        svg,
-        &svg.view_box(),
-        &ts.pre_concat(svg.view_box().to_transform(svg.size())),
-        error_handler,
-    )
+    render_tree_impl(scene, svg, &svg.view_box(), ts, error_handler)
 }
 
 fn render_tree_impl<F: FnMut(&mut Scene, &usvg::Node) -> Result<(), E>, E>(
@@ -90,6 +84,7 @@ fn render_tree_impl<F: FnMut(&mut Scene, &usvg::Node) -> Result<(), E>, E>(
     ts: &usvg::Transform,
     error_handler: &mut F,
 ) -> Result<(), E> {
+    let ts = &ts.pre_concat(view_box.to_transform(svg.size()));
     let transform = to_affine(ts);
     scene.push_layer(
         BlendMode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ fn render_tree_impl<F: FnMut(&mut Scene, &usvg::Node) -> Result<(), E>, E>(
     );
     let (view_box_transform, clip) =
         geom::view_box_to_transform_with_clip(view_box, svg.size().to_int_size());
-    let view_box_transform = view_box_transform.pre_concat(svg.view_box().to_transform(svg.size()));
+    let view_box_transform = view_box_transform.pre_concat(view_box.to_transform(svg.size()));
     if let Some(clip) = clip {
         scene.push_layer(
             BlendMode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub fn render_tree(scene: &mut Scene, svg: &usvg::Tree) {
     render_tree_with::<_, Infallible>(
         scene,
         svg,
-        &svg.view_box().to_transform(svg.size()),
+        &usvg::Transform::identity(),
         &mut default_error_handler,
     )
     .unwrap_or_else(|e| match e {});


### PR DESCRIPTION
Before and after for reference. Also adds a missing changelog item.

<img width="1060" alt="image" src="https://github.com/linebender/vello_svg/assets/48108917/18338d27-7e5b-4b6f-bfaf-cb95046ec973">

<img width="1060" alt="image" src="https://github.com/linebender/vello_svg/assets/48108917/9bd8b128-fcc7-41f6-a5fc-794d3c535edb">
