### PR TITLE
Replace vello's default `wgpu` feature with an optional `wgpu` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+- Disable `vello`'s default `wgpu` feature, and provide a `wgpu` passthrough feature to turn it back on. [#10](https://github.com/linebender/vello_svg/pull/10)
+
 ### Changed
 
 - Updated `usvg` to 0.41

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/linebender/vello_svg"
 
 [workspace.dependencies]
 # NOTE: Make sure to keep this in sync with the version badge in README.md
-vello = "0.1.0"
+vello = { version = "0.1.0", default-features = false }
 
 [package]
 name = "vello_svg"
@@ -22,7 +22,6 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 vello = { workspace = true }
 usvg = "0.41.0"
@@ -35,3 +34,7 @@ image = { version = "0.25.0", default-features = false, features = [
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.42"
+
+[features]
+# Enables the wgpu feature on vello, which is disabled by default
+wgpu = ["vello/wgpu"]

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -17,7 +17,7 @@ name = "with_winit_bin"
 path = "src/main.rs"
 
 [dependencies]
-vello = { workspace = true, features = ["buffer_labels", "wgpu-profiler"] }
+vello = { workspace = true, features = ["buffer_labels", "wgpu", "wgpu-profiler"] }
 scenes = { path = "../scenes" }
 anyhow = "1"
 clap = { version = "4.5.1", features = ["derive"] }
@@ -30,7 +30,7 @@ env_logger = "0.11.2"
 log = "0.4.21"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
-vello = { workspace = true, features = ["hot_reload", "wgpu-profiler"] }
+vello = { workspace = true, features = ["hot_reload", "wgpu", "wgpu-profiler"] }
 notify-debouncer-mini = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
https://github.com/linebender/vello/pull/359 made `wgpu` an optional but default dependency/feature, but any crate using `vello_svg` will be forced to opt in to `wgpu` due to not disabling the default here.

Since `vello_svg` does not need any rendering backend at all, this feature should be disabled by default.  As the `vello` crate is reexported from the root, a `vello-wgpu` passthrough feature is provided so that users can turn it back on without explicitly depending on `vello` in their crate dependencies.

Same change as https://github.com/linebender/velato/pull/17.
