### PR TITLE
Render text + fix transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.75.
 
+### Added
+
+- Support for rendering basic text
+
+### Fixed
+
+- Transform of nested SVGs
+
 ## 0.3.0
 
 This release has an [MSRV][] of 1.75.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use vello;
 
 /// Re-export usvg.
 pub use usvg;
+use vello::kurbo::Affine;
 
 /// Render a [`Scene`] from an SVG string, with default error handling.
 ///
@@ -95,5 +96,5 @@ pub fn append_tree_with<F: FnMut(&mut vello::Scene, &usvg::Node)>(
     svg: &usvg::Tree,
     error_handler: &mut F,
 ) {
-    render::render_group(scene, svg.root(), error_handler);
+    render::render_group(scene, svg.root(), Affine::IDENTITY, error_handler);
 }


### PR DESCRIPTION
Fixes #16

This enables naive text rendering support using usvg's support for flattening text into paths. It also fixes application of transform for nested SVGs.

With this patch, `vello_svg` can now render the "badges" from the Xilem README:

<img width="726" alt="Screenshot 2024-07-29 at 11 14 21" src="https://github.com/user-attachments/assets/4ddea064-7ea6-42ff-9570-0c138e76529e">
