### PR TITLE
scenes: Don't need a dependency on `image`

### DIFF
--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -14,7 +14,6 @@ vello = { workspace = true }
 vello_svg = { path = "../.." }
 anyhow = "1"
 clap = { version = "4.5.1", features = ["derive"] }
-image = "0.24.9"
 rand = "0.8.5"
 instant = "0.1"
 


### PR DESCRIPTION
This was not the same version used in the main crate, so this gets rid of an extra version of the `images` crate (0.24).