### PR TITLE
Add a dummy test to satisfy `nextest`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,3 +100,11 @@ pub fn append_tree_with<F: FnMut(&mut vello::Scene, &usvg::Node)>(
 ) {
     render::render_group(scene, svg.root(), Affine::IDENTITY, error_handler);
 }
+
+#[cfg(test)]
+mod tests {
+    // CI will fail unless it can execute at least one test per workspace.
+    // Delete this dummy test once we have an actual real test.
+    #[test]
+    fn dummy_test_until_we_have_a_real_test() {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub fn append_tree_with<F: FnMut(&mut vello::Scene, &usvg::Node)>(
 
 #[cfg(test)]
 mod tests {
-    // CI will fail unless it can execute at least one test per workspace.
+    // CI will fail unless cargo nextest can execute at least one test per workspace.
     // Delete this dummy test once we have an actual real test.
     #[test]
     fn dummy_test_until_we_have_a_real_test() {}


### PR DESCRIPTION
Keeps the CI functioning with test running assurances.