### PR TITLE
Feature flag raster image formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find its changes [documented below](#050-2024-11-20).
 
 This release has an [MSRV][] of 1.75.
 
+### Changed
+
+- Feature flag raster image formats (enabled by default) ([#50] by [@nicoburns])
+
 ## [0.5.0][] (2024-11-20)
 
 This release has an [MSRV][] of 1.75.
@@ -107,6 +111,7 @@ This release has an [MSRV][] of 1.75.
 [@MarijnS95]: https://github.com/MarijnS95
 [@DasLixou]: https://github.com/DasLixou
 
+[#50]: https://github.com/linebender/vello_svg/pull/50
 [#42]: https://github.com/linebender/vello_svg/pull/42
 [#34]: https://github.com/linebender/vello_svg/pull/34
 [#31]: https://github.com/linebender/vello_svg/pull/31

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,11 +105,11 @@ image = { version = "0.25.5", default-features = false, features = [ "webp", "pn
 wasm-bindgen-test = "0.3.49"
 
 [features]
-default = ["image", "png", "gif", "jpeg", "webp"]
+default = ["image", "image_format_png", "image_format_gif", "image_format_jpeg", "image_format_webp"]
 # Enables the wgpu feature on vello, which is disabled by default
 wgpu = ["vello/wgpu"]
 image = ["dep:image"]
-png = ["image", "image/png"]
-jpeg = ["image", "image/jpeg"]
-gif = ["image", "image/gif"]
-webp = ["image", "image/webp"]
+image_format_png = ["image", "image/png"]
+image_format_jpeg = ["image", "image/jpeg"]
+image_format_gif = ["image", "image/gif"]
+image_format_webp = ["image", "image/webp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,16 +99,17 @@ workspace = true
 vello = { workspace = true }
 thiserror = "1.0.69"
 usvg = "0.44.0"
-image = { version = "0.25.5", default-features = false, features = [
-  "webp",
-  "png",
-  "jpeg",
-  "gif",
-] }
+image = { version = "0.25.5", default-features = false, features = [ "webp", "png", "jpeg", "gif"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.49"
 
 [features]
+default = ["image", "png", "gif", "jpeg", "webp"]
 # Enables the wgpu feature on vello, which is disabled by default
 wgpu = ["vello/wgpu"]
+image = ["dep:image"]
+png = ["image", "image/png"]
+jpeg = ["image", "image/jpeg"]
+gif = ["image", "image/gif"]
+webp = ["image", "image/webp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ image = { version = "0.25.5", default-features = false, features = [ "webp", "pn
 wasm-bindgen-test = "0.3.49"
 
 [features]
-default = ["image", "image_format_png", "image_format_gif", "image_format_jpeg", "image_format_webp"]
+default = ["image_format_png", "image_format_gif", "image_format_jpeg", "image_format_webp"]
 # Enables the wgpu feature on vello, which is disabled by default
 wgpu = ["vello/wgpu"]
 image = ["dep:image"]


### PR DESCRIPTION
## Notes

- Fixes #47
- Allows support for raster images to be completely disabled as well as flagging individual formats (allows the `image` dependency to be disabled entirely as `image` is surprisingly large even with no formats enabled)