### PR TITLE
Fix conversion from `usvg::Transform` to `kurbo::Affine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,9 @@ You can find its changes [documented below](#070-2025-05-21).
 
 ## [Unreleased][]
 
-## Changed
-
-- Corrects kx and ky when transforming usvg::Transform to kurbo::Affine to align rotations correctly. ([#63][] by [@RobertBrewitz][])
-
 ## Fixed
 
-- Svg rotations are now correctly handled. ([#63][] by [@RobertBrewitz][])
+- Svg rotations are now correctly handled (Corrects kx and ky when transforming usvg::Transform to kurbo::Affine) ([#63][] by [@RobertBrewitz][])
 
 This release has an [MSRV][] of 1.85.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ You can find its changes [documented below](#070-2025-05-21).
 
 ## [Unreleased][]
 
+## Changed
+
+- Corrects kx and ky when transforming usvg::Transform to kurbo::Affine to align rotations correctly. ([#63][] by [@RobertBrewitz][])
+
+## Fixed
+
+- Svg rotations are now correctly handled. ([#63][] by [@RobertBrewitz][])
+
 This release has an [MSRV][] of 1.85.
 
 ## [0.7.0][] (2025-05-21)

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub fn to_affine(ts: &usvg::Transform) -> Affine {
         tx,
         ty,
     } = ts;
-    Affine::new([sx, kx, ky, sy, tx, ty].map(|&x| f64::from(x)))
+    Affine::new([sx, ky, kx, sy, tx, ty].map(|&x| f64::from(x)))
 }
 
 pub fn to_stroke(stroke: &usvg::Stroke) -> Stroke {

--- a/tests/util_to_affine_test.rs
+++ b/tests/util_to_affine_test.rs
@@ -4,12 +4,13 @@
 #![allow(missing_docs, reason = "regression test for util::to_affine")]
 #[cfg(test)]
 pub mod util_to_affine_test {
+    use usvg::Transform;
     use vello::kurbo::Affine;
     use vello_svg::util::to_affine;
 
     #[test]
     fn regression_test() {
-        let usvg_transform = usvg::Transform {
+        let usvg_transform = Transform {
             sx: 1.,
             kx: 2.,
             ky: 3.,

--- a/tests/util_to_affine_test.rs
+++ b/tests/util_to_affine_test.rs
@@ -1,0 +1,23 @@
+#![allow(missing_docs, reason = "regression test for util::to_affine")]
+#[cfg(test)]
+pub mod util_to_affine_test {
+    use vello::kurbo::Affine;
+    use vello_svg::util::to_affine;
+
+    #[test]
+    fn regression_test() {
+        let usvg_transform = usvg::Transform {
+            sx: 1.,
+            kx: 2.,
+            ky: 3.,
+            sy: 4.,
+            tx: 5.,
+            ty: 6.,
+        };
+
+        let result = to_affine(&usvg_transform);
+        let expected = Affine::new([1.0, 3.0, 2.0, 4.0, 5.0, 6.0]);
+
+        assert_eq!(result, expected);
+    }
+}

--- a/tests/util_to_affine_test.rs
+++ b/tests/util_to_affine_test.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![allow(missing_docs, reason = "regression test for util::to_affine")]
 #[cfg(test)]
 pub mod util_to_affine_test {


### PR DESCRIPTION
This is a result of investigating this issue: https://github.com/linebender/bevy_vello/issues/28

~~Seems by just flipping the signs on the kx and ky, the rotations are fixed, I have not yet investigated what impact it has on other things though.~~

Corrects the transformation from usvg::Transform to kurbo::Affine.

On closer investigation, we have the following

```rust
// usvg::Transform(sx, kx, ky, sy, tx, ty)
pub struct Transform {
    pub sx: f32,
    pub kx: f32,
    pub ky: f32,
    pub sy: f32,
    pub tx: f32,
    pub ty: f32,
}
```

```rust
// | a c e |
// | b d f |
// | 0 0 1 |
//
// which corresponds to
//
// | scale_x skew_x translate_x |
// | skew_y scale_y translate_y |
// | skew_z skew_z scale_z |

pub struct Affine([f64; 6]);
```

But, before this change it was miss-alinged and we transformed it to the following:

```rust
// | a b e |
// | c d f |
// | 0 0 1 |
//
// which corresponds to
//
// | scale_x skew_y translate_x |
// | skew_x scale_y translate_y |
// | skew_z skew_z scale_z |
```

SVG from: https://gist.github.com/kristoff3r/b1e510635363e95caa5511534277d6ba

## Old behavior

![old_behavior](https://github.com/user-attachments/assets/a7d18f71-167e-412d-9374-b56bf9d538c2)

## New behavior with the change

![new_behavior](https://github.com/user-attachments/assets/32153b0e-85da-4258-aac2-099681dd7f88)
