### PR TITLE
feat(render): multi-child clip-path and mask emission (closes #72)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -3,8 +3,8 @@
 
 use crate::util;
 use vello::Scene;
-use vello::kurbo::Affine;
-use vello::peniko::{BlendMode, Fill};
+use vello::kurbo::{Affine, BezPath, Rect};
+use vello::peniko::{BlendMode, Compose, Fill, Mix};
 
 pub(crate) fn render_group<F: FnMut(&mut Scene, &usvg::Node)>(
     scene: &mut Scene,
@@ -18,52 +18,61 @@ pub(crate) fn render_group<F: FnMut(&mut Scene, &usvg::Node)>(
             usvg::Node::Group(g) => {
                 let alpha = g.opacity().get();
                 let blend_mode: BlendMode = match g.blend_mode() {
-                    usvg::BlendMode::Normal => vello::peniko::Mix::Normal.into(),
-                    usvg::BlendMode::Multiply => vello::peniko::Mix::Multiply.into(),
-                    usvg::BlendMode::Screen => vello::peniko::Mix::Screen.into(),
-                    usvg::BlendMode::Overlay => vello::peniko::Mix::Overlay.into(),
-                    usvg::BlendMode::Darken => vello::peniko::Mix::Darken.into(),
-                    usvg::BlendMode::Lighten => vello::peniko::Mix::Lighten.into(),
-                    usvg::BlendMode::ColorDodge => vello::peniko::Mix::ColorDodge.into(),
-                    usvg::BlendMode::ColorBurn => vello::peniko::Mix::ColorBurn.into(),
-                    usvg::BlendMode::HardLight => vello::peniko::Mix::HardLight.into(),
-                    usvg::BlendMode::SoftLight => vello::peniko::Mix::SoftLight.into(),
-                    usvg::BlendMode::Difference => vello::peniko::Mix::Difference.into(),
-                    usvg::BlendMode::Exclusion => vello::peniko::Mix::Exclusion.into(),
-                    usvg::BlendMode::Hue => vello::peniko::Mix::Hue.into(),
-                    usvg::BlendMode::Saturation => vello::peniko::Mix::Saturation.into(),
-                    usvg::BlendMode::Color => vello::peniko::Mix::Color.into(),
-                    usvg::BlendMode::Luminosity => vello::peniko::Mix::Luminosity.into(),
+                    usvg::BlendMode::Normal => Mix::Normal.into(),
+                    usvg::BlendMode::Multiply => Mix::Multiply.into(),
+                    usvg::BlendMode::Screen => Mix::Screen.into(),
+                    usvg::BlendMode::Overlay => Mix::Overlay.into(),
+                    usvg::BlendMode::Darken => Mix::Darken.into(),
+                    usvg::BlendMode::Lighten => Mix::Lighten.into(),
+                    usvg::BlendMode::ColorDodge => Mix::ColorDodge.into(),
+                    usvg::BlendMode::ColorBurn => Mix::ColorBurn.into(),
+                    usvg::BlendMode::HardLight => Mix::HardLight.into(),
+                    usvg::BlendMode::SoftLight => Mix::SoftLight.into(),
+                    usvg::BlendMode::Difference => Mix::Difference.into(),
+                    usvg::BlendMode::Exclusion => Mix::Exclusion.into(),
+                    usvg::BlendMode::Hue => Mix::Hue.into(),
+                    usvg::BlendMode::Saturation => Mix::Saturation.into(),
+                    usvg::BlendMode::Color => Mix::Color.into(),
+                    usvg::BlendMode::Luminosity => Mix::Luminosity.into(),
                 };
 
-                let clipped = match g
-                    .clip_path()
-                    // support clip-path with a single path
-                    .and_then(|path| path.root().children().first())
-                {
-                    Some(usvg::Node::Path(clip_path)) => {
-                        let local_path = util::to_bez_path(clip_path);
-                        scene.push_layer(Fill::NonZero, blend_mode, alpha, transform, &local_path);
+                // Build the group's clip shape: either the union of every
+                // path inside `clip-path` (including paths nested in groups
+                // within the clip-path), or the group's bounding box as a
+                // fallback when no clip-path is set. Previously this only
+                // honoured a single-child clip-path and silently degraded
+                // anything more complex to a bbox-only clip — see
+                // linebender/vello_svg#72.
+                let (clip_shape, is_compound) = build_clip_shape(g);
 
-                        true
-                    }
-                    _ => {
-                        // Use bounding box as the clip path.
-                        let bounding_box = g.layer_bounding_box();
-                        let rect = vello::kurbo::Rect::from_origin_size(
-                            (bounding_box.x(), bounding_box.y()),
-                            (bounding_box.width() as f64, bounding_box.height() as f64),
-                        );
-                        scene.push_layer(Fill::NonZero, blend_mode, alpha, transform, &rect);
-                        true
-                    }
-                };
+                if is_compound {
+                    scene.push_layer(
+                        Fill::NonZero,
+                        blend_mode,
+                        alpha,
+                        transform,
+                        clip_shape.as_path(),
+                    );
+                } else {
+                    scene.push_layer(
+                        Fill::NonZero,
+                        blend_mode,
+                        alpha,
+                        transform,
+                        clip_shape.as_rect(),
+                    );
+                }
 
                 render_group(scene, g, Affine::IDENTITY, error_handler);
 
-                if clipped {
-                    scene.pop_layer();
+                // Apply the group's `<mask>` (if any) by drawing the mask's
+                // rendered content as either a luminance or alpha mask over
+                // the group's content. Previously masks were ignored.
+                if let Some(mask) = g.mask() {
+                    apply_mask(scene, mask, transform, error_handler);
                 }
+
+                scene.pop_layer();
             }
             usvg::Node::Path(path) => {
                 if !path.is_visible() {
@@ -157,4 +166,92 @@ pub(crate) fn render_group<F: FnMut(&mut Scene, &usvg::Node)>(
             }
         }
     }
+}
+
+/// The clip shape for a group: either a compound `BezPath` built from every
+/// path inside the group's `clip-path`, or the group's `layer_bounding_box`
+/// rect as a fallback when no `clip-path` is set.
+enum ClipShape {
+    Compound(BezPath),
+    BBox(Rect),
+}
+
+impl ClipShape {
+    fn as_path(&self) -> &BezPath {
+        match self {
+            Self::Compound(p) => p,
+            Self::BBox(_) => unreachable!("caller checked is_compound"),
+        }
+    }
+    fn as_rect(&self) -> &Rect {
+        match self {
+            Self::BBox(r) => r,
+            Self::Compound(_) => unreachable!("caller checked is_compound"),
+        }
+    }
+}
+
+fn build_clip_shape(g: &usvg::Group) -> (ClipShape, bool) {
+    if let Some(clip_path) = g.clip_path() {
+        let mut compound = BezPath::new();
+        collect_clip_paths(clip_path.root(), &mut compound);
+        if !compound.elements().is_empty() {
+            return (ClipShape::Compound(compound), true);
+        }
+    }
+    let bb = g.layer_bounding_box();
+    let rect = Rect::from_origin_size((bb.x(), bb.y()), (bb.width() as f64, bb.height() as f64));
+    (ClipShape::BBox(rect), false)
+}
+
+/// Walk a clip-path's tree appending every `<path>` into `out`. Nested
+/// groups (e.g. clip-path with `<g><path/><path/></g>`) recurse so all
+/// reachable paths contribute. Non-path nodes (images, text) are ignored —
+/// SVG only allows shape elements in clipPaths, but usvg may expose
+/// flattened text as groups of paths, which this picks up naturally.
+fn collect_clip_paths(group: &usvg::Group, out: &mut BezPath) {
+    for child in group.children() {
+        match child {
+            usvg::Node::Path(p) => {
+                out.extend(util::to_bez_path(p).iter());
+            }
+            usvg::Node::Group(g) => collect_clip_paths(g, out),
+            _ => {}
+        }
+    }
+}
+
+/// Composite a usvg `<mask>` onto the current layer. Uses vello's
+/// `push_luminance_mask_layer` for luminance-mode masks (the SVG default)
+/// and a `Compose::DestIn` layer for alpha-mode masks.
+///
+/// The mask's own `mask.mask()` (a mask on the mask) is currently not
+/// honoured — nested masking is rare and left as a follow-up.
+fn apply_mask<F: FnMut(&mut Scene, &usvg::Node)>(
+    scene: &mut Scene,
+    mask: &usvg::Mask,
+    transform: Affine,
+    error_handler: &mut F,
+) {
+    let mr = mask.rect();
+    let mask_rect = Rect::from_origin_size(
+        (mr.x() as f64, mr.y() as f64),
+        (mr.width() as f64, mr.height() as f64),
+    );
+    match mask.kind() {
+        usvg::MaskType::Luminance => {
+            scene.push_luminance_mask_layer(Fill::NonZero, 1.0, transform, &mask_rect);
+        }
+        usvg::MaskType::Alpha => {
+            scene.push_layer(
+                Fill::NonZero,
+                BlendMode::new(Mix::Normal, Compose::DestIn),
+                1.0,
+                transform,
+                &mask_rect,
+            );
+        }
+    }
+    render_group(scene, mask.root(), Affine::IDENTITY, error_handler);
+    scene.pop_layer();
 }

--- a/tests/clip_and_mask_test.rs
+++ b/tests/clip_and_mask_test.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Render-tree-builds-without-panic tests for the multi-child clip-path
+//! and mask emit paths added to `render::render_group`. These don't
+//! verify pixel output (that requires a GPU), but they do exercise the
+//! `Scene` encoding so wrong layer/pop pairing or invalid arguments
+//! would crash via `vello::Scene::pop_layer` assertion failures.
+
+#![allow(missing_docs, reason = "regression tests")]
+
+#[cfg(test)]
+mod tests {
+    use usvg::{Options, Tree};
+    use vello_svg::render_tree;
+
+    fn parse(svg: &str) -> Tree {
+        Tree::from_str(svg, &Options::default()).expect("parse SVG")
+    }
+
+    #[test]
+    fn multi_child_clip_path_renders_without_panic() {
+        let tree = parse(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+                <defs>
+                  <clipPath id="cp">
+                    <circle cx="20" cy="32" r="14"/>
+                    <circle cx="44" cy="32" r="14"/>
+                  </clipPath>
+                </defs>
+                <g clip-path="url(#cp)">
+                  <rect x="0" y="0" width="64" height="64" fill="#1b75d0"/>
+                </g>
+              </svg>"##,
+        );
+        let _scene = render_tree(&tree);
+    }
+
+    #[test]
+    fn nested_group_inside_clip_path_renders_without_panic() {
+        // Two paths inside a <g> inside the clipPath. The recursive
+        // walker should collect both.
+        let tree = parse(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+                <defs>
+                  <clipPath id="cp">
+                    <g>
+                      <rect x="0" y="0" width="32" height="32"/>
+                      <rect x="32" y="32" width="32" height="32"/>
+                    </g>
+                  </clipPath>
+                </defs>
+                <g clip-path="url(#cp)">
+                  <rect x="0" y="0" width="64" height="64" fill="#1b75d0"/>
+                </g>
+              </svg>"##,
+        );
+        let _scene = render_tree(&tree);
+    }
+
+    #[test]
+    fn luminance_mask_renders_without_panic() {
+        let tree = parse(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+                <defs>
+                  <linearGradient id="lg" x1="0" y1="0" x2="0" y2="64" gradientUnits="userSpaceOnUse">
+                    <stop offset="0" stop-color="#fff"/>
+                    <stop offset="1" stop-color="#000"/>
+                  </linearGradient>
+                  <mask id="m" maskUnits="userSpaceOnUse" x="0" y="0" width="64" height="64">
+                    <rect x="0" y="0" width="64" height="64" fill="url(#lg)"/>
+                  </mask>
+                </defs>
+                <g mask="url(#m)">
+                  <rect x="0" y="0" width="64" height="64" fill="#1b75d0"/>
+                </g>
+              </svg>"##,
+        );
+        let _scene = render_tree(&tree);
+    }
+
+    #[test]
+    fn alpha_mask_renders_without_panic() {
+        // mask-type="alpha" — uses the source's alpha channel directly
+        // instead of converting to luminance.
+        let tree = parse(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+                <defs>
+                  <mask id="m" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="64" height="64">
+                    <rect x="0" y="0" width="32" height="64" fill="#000" fill-opacity="0.5"/>
+                  </mask>
+                </defs>
+                <g mask="url(#m)">
+                  <rect x="0" y="0" width="64" height="64" fill="#1b75d0"/>
+                </g>
+              </svg>"##,
+        );
+        let _scene = render_tree(&tree);
+    }
+
+    #[test]
+    fn empty_clip_path_falls_back_to_bbox() {
+        // A clipPath with no children should not panic — we fall back
+        // to the group's `layer_bounding_box` rect.
+        let tree = parse(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+                <defs>
+                  <clipPath id="cp"/>
+                </defs>
+                <g clip-path="url(#cp)">
+                  <rect x="0" y="0" width="64" height="64" fill="#1b75d0"/>
+                </g>
+              </svg>"##,
+        );
+        let _scene = render_tree(&tree);
+    }
+}


### PR DESCRIPTION
## Summary

- **Multi-child `clip-path`** (closes #72): `render_group` now walks the entire `clip-path` subtree and unions every `<path>` it contains into a single `BezPath`, recursing through nested `<g>` containers. Previously only a single top-level child of `clipPath` was honoured; multi-path clips silently degraded to the group's bounding-box.
- **Mask emission** (was listed under "unsupported features"): `apply_mask` routes `MaskType::Luminance` to `Scene::push_luminance_mask_layer` and `MaskType::Alpha` to a `Compose::DestIn` layer, composing the mask after the group's children render. Nested masks (`Mask::mask`) are not yet honoured — TODO.
- 5 `render_tree`-builds-without-panic regression tests in `tests/clip_and_mask_test.rs` covering both code paths plus the empty-`<clipPath/>` edge case.

## Test plan

```
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
```

All green locally. The new tests exercise the `Scene` encoding end-to-end so a mismatched `push_layer` / `pop_layer` pair would crash on `Scene::pop_layer`'s assertion.

## Visual verification

Cross-rendered a 49-icon XDG `.desktop` corpus through both `vello_svg` (on this branch) and `resvg` at 1024×1024, normalising both to premultiplied RGBA before comparing (vello's `Rgba8Unorm` output is straight; `tiny_skia::Pixmap::data()` is premultiplied — comparing the raw bytes without normalising made my early "mask is broken" reading look much worse than reality).

After this change:

|                                  | mad pre-fix | mad post-fix |
| -------------------------------- | ----------- | ------------ |
| `org.gnome.Snapshot` (mask)      | 8.68        | 5.69 (residual = filter primitives, #1296) |
| synthetic luminance-mask gradient | ~44        | **0.35** |
| synthetic two-halves mask        |  0          | 0           |
| synthetic multi-child clipPath   |  ~AA noise  | 0.05        |
| `qv4l2` family                   | ~5.4        | ~5.4 (gradient-alpha lerp, #1657) |
| `audacity` (filter)              | 14.4        | 14.2        |
| AA-noise icons                   | <1.0        | <1.0        |

The harness, reproducer SVGs, and side-by-side outputs live under `icon-corpus/` in https://github.com/mxaddict/vello_svg/tree/fix/gradient-transform-composition/icon-corpus for anyone who wants to reproduce.

## Notes

- Nested masks (`<mask><g mask="…">…</g></mask>`) are rare and intentionally deferred.
- The "group background" / `enable-background` and SVG filter primitives are still unsupported here — the latter is already tracked at linebender/vello#1296.
- Existing single-child clipPath paths continue to take the same code path (compound `BezPath` of one path == `BezPath::extend(single_path.iter())`).
